### PR TITLE
feat: updated mockContext for new auth service

### DIFF
--- a/lib/tests/mockContext.js
+++ b/lib/tests/mockContext.js
@@ -16,8 +16,8 @@ const mockContext = {
   queries: {},
   userHasPermission: jest.fn().mockName("userHasPermission"),
   userHasPermissionLegacy: jest.fn().mockName("userHasPermissionLegacy"),
-  verifyPermissions: jest.fn().mockName("verifyPermissions"),
-  verifyPermissionsLegacy: jest.fn().mockName("verifyPermissionsLegacy"),
+  validatePermissions: jest.fn().mockName("validatePermissions"),
+  validatePermissionsLegacy: jest.fn().mockName("validatePermissionsLegacy"),
   userId: "FAKE_USER_ID"
 };
 

--- a/lib/tests/mockContext.js
+++ b/lib/tests/mockContext.js
@@ -6,7 +6,6 @@ const mockContext = {
     emit() { },
     on() { }
   },
-  validatePermissions: jest.fn().mockName("validatePermissions"),
   collections: {},
   getAbsoluteUrl: jest.fn().mockName("getAbsoluteUrl").mockImplementation((path) => {
     const adjustedPath = path[0] === "/" ? path : `/${path}`;
@@ -16,6 +15,9 @@ const mockContext = {
   mutations: {},
   queries: {},
   userHasPermission: jest.fn().mockName("userHasPermission"),
+  userHasPermissionLegacy: jest.fn().mockName("userHasPermissionLegacy"),
+  verifyPermissions: jest.fn().mockName("verifyPermissions"),
+  verifyPermissionsLegacy: jest.fn().mockName("verifyPermissionsLegacy"),
   userId: "FAKE_USER_ID"
 };
 


### PR DESCRIPTION
updated `mockContext` to add `keto` and `legacy` versions of auth service functions.

This will need to be merged in order for tests to work here https://github.com/reactioncommerce/reaction/pull/5772