### PR TITLE
fix: remove legacy auth mockContext functions that aren't needed

### DIFF
--- a/lib/tests/mockContext.js
+++ b/lib/tests/mockContext.js
@@ -15,9 +15,7 @@ const mockContext = {
   mutations: {},
   queries: {},
   userHasPermission: jest.fn().mockName("userHasPermission"),
-  userHasPermissionLegacy: jest.fn().mockName("userHasPermissionLegacy"),
   validatePermissions: jest.fn().mockName("validatePermissions"),
-  validatePermissionsLegacy: jest.fn().mockName("validatePermissionsLegacy"),
   userId: "FAKE_USER_ID"
 };
 


### PR DESCRIPTION
Remove `legacy` functions that were once thought to be needed, but are no longer after a refactor.