### PR TITLE
fix: update branch name on ci publishing

### DIFF
--- a/.circleci/bin/docker-tags
+++ b/.circleci/bin/docker-tags
@@ -26,7 +26,7 @@ git show-ref --tags -d | grep "^${SHA1}" | sed -e 's,.* refs/tags/,,' -e 's/\^{}
   echo "%"
 
 # Tag with latest if certain conditions are met
-if [[ "$BRANCH" == "master" ]]; then
+if [[ "$BRANCH" == "trunk" ]]; then
   # Check to see if we have a valid `vX.X.X` tag and assign to CURRENT_TAG
   CURRENT_TAG=$( \
     git show-ref --tags -d \


### PR DESCRIPTION
Branch name was `master` in docker-tags file, this needs to be updated to be `trunk`