### PR TITLE
Add getPaginatedResponseFromAggregate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 ## Methods
 
-- [getPaginatedResponseFromAggregate](https://github.com/reactioncommerce/api-utils/)
+- [getPaginatedResponseFromAggregate](./getPaginatedResponseFromAggregate.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# api-utils
+
+## Methods
+
+- [getPaginatedResponseFromAggregate](https://github.com/reactioncommerce/api-utils/)

--- a/docs/getPaginatedResponseFromAggregate.md
+++ b/docs/getPaginatedResponseFromAggregate.md
@@ -25,11 +25,12 @@ const pipeline = [
 
 const args = {
   // connection arguments from your GraphQL query or mutation
+  // more info here: https://facebook.github.io/relay/graphql/connections.htm#sec-Arguments
   // supported:
   // offset: Int,
   // last: Int,
   // sortBy: String (the name of the MongoDB field you want to sort results by)
-  // sortOrder: Int (-1 for descending or 1 for ascending)
+  // sortOrder: String ("desc" for descending, or "asc" for ascending)
 };
 
 const options = {

--- a/docs/getPaginatedResponseFromAggregate.md
+++ b/docs/getPaginatedResponseFromAggregate.md
@@ -41,4 +41,17 @@ const options = {
 };
 
 const results = await getPaginatedResponseFromAggregate(collection, pipeline, args, options);
+
+return results;
+// {
+//   pipeline: Array (the pipeline that was passed, with the necessary modifications that were added to it by `getPaginatedResponseFromAggregate`)
+//   nodes: Array (the returned items)
+//   pageInfo: Object {
+//     `hasNextPage: Boolean` (if requested in `options`),
+//     `hasPreviousPage: Boolean` (if requested in `options`),
+//     `startCursor`: String (`_id` of the first item in `nodes`),
+//     `endCursor`: String (`_id of the last item in `nodes`)
+//   },
+//   totalCount: Int (if requested in `options`)
+// }
 ```

--- a/docs/getPaginatedResponseFromAggregate.md
+++ b/docs/getPaginatedResponseFromAggregate.md
@@ -1,0 +1,44 @@
+# getPaginatedResponseFromAggregate
+
+Returns a paginated response from a MongoDB aggregation pipeline.
+
+Usage example:
+
+```js
+import getPaginatedResponseFromAggregate from "@reactioncommerce/api-utils/getPaginatedResponseFromAggregate.js";
+
+// the MongoDB collection you want to run your aggregation on
+const collection = getYourMongoDBCollectionSomehow();
+
+const pipeline = [
+  {
+    // for example, here's a $lookup operator
+    $lookup: {
+      // some options
+    }
+  },
+  // but you can add,
+  // any,
+  // other,
+  // operators
+];
+
+const args = {
+  // connection arguments from your GraphQL query or mutation
+  // supported:
+  // offset: Int,
+  // last: Int,
+  // sortBy: String (the name of the MongoDB field you want to sort results by)
+  // sortOrder: Int (-1 for descending or 1 for ascending)
+};
+
+const options = {
+  // some options to control which optional fields get returned with the results
+  // supported:
+  // includeHasNextPage: Boolean,
+  // includeHasPreviousPage: Boolean,
+  // includeTotalCount: Boolean
+};
+
+const results = await getPaginatedResponseFromAggregate(collection, pipeline, args, options);
+```

--- a/docs/getPaginatedResponseFromAggregate.md
+++ b/docs/getPaginatedResponseFromAggregate.md
@@ -28,6 +28,7 @@ const args = {
   // more info here: https://facebook.github.io/relay/graphql/connections.htm#sec-Arguments
   // supported:
   // offset: Int,
+  // first: Int,
   // last: Int,
   // sortBy: String (the name of the MongoDB field you want to sort results by)
   // sortOrder: String ("desc" for descending, or "asc" for ascending)

--- a/lib/graphql/__snapshots__/applyPaginationToMongoAggregate.test.js.snap
+++ b/lib/graphql/__snapshots__/applyPaginationToMongoAggregate.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with both first and last, throws error 1`] = `"Request either \`first\` or \`last\` but not both"`;

--- a/lib/graphql/applyOffsetPaginationToMongoAggregate.js
+++ b/lib/graphql/applyOffsetPaginationToMongoAggregate.js
@@ -1,0 +1,57 @@
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Inspired by https://www.reindex.io/blog/relay-graphql-pagination-with-mongodb/
+ * @name applyOffsetPaginationToMongoAggregate
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Adds `skip` and `limit` to a MongoDB aggregation pipeline as necessary, based on GraphQL
+ *   `first` and `offset` params
+ * @param {MongoDB.Collection} collection MongoDB collection to run the aggregation pipeline on
+ * @param {Array} pipeline MongoDB aggregation pipeline
+ * @param {Object} args An object with `offset` or `last` but not both.
+ * @param {Object} options Options
+ * @param {Boolean} [options.includeHasNextPage] Whether to return the `pageInfo.hasNextPage`.
+ *   Default is `true`. Set this to `false` if you don't need it to avoid an extra database command.
+ * @return {Promise<Object>} `{ hasNextPage, hasPreviousPage, pipeline }`
+ */
+export default async function applyOffsetPaginationToMongoAggregate(collection, pipeline, { first, offset } = {}, {
+  includeHasNextPage = true
+} = {}) {
+  // Enforce a `first: 20` limit if no user-supplied limit, using the DEFAULT_LIMIT
+  const limit = first || DEFAULT_LIMIT;
+
+  // Apply limit + skip to the provided pipeline
+  pipeline.push({
+    "$limit": limit
+  });
+
+  pipeline.push({
+    "$skip": offset
+  });
+
+  let hasNextPage = null;
+
+  const hasPreviousPage = offset > 0;
+
+  if (includeHasNextPage) {
+    const nextPipeline = [...pipeline];
+    nextPipeline.push({
+      "$skip": offset + limit
+    });
+    nextPipeline.push({
+      "$limit": 1
+    });
+
+    const nextCursor = collection.aggregate(pipeline);
+    const nextDoc = await nextCursor.hasNext();
+    hasNextPage = !!nextDoc;
+  }
+
+  return {
+    hasNextPage,
+    hasPreviousPage,
+    pipeline
+  };
+}
+

--- a/lib/graphql/applyOffsetPaginationToMongoAggregate.test.js
+++ b/lib/graphql/applyOffsetPaginationToMongoAggregate.test.js
@@ -1,0 +1,53 @@
+import getFakeMongoCollection from "../tests/getFakeMongoCollection.js";
+import applyOffsetPaginationToMongoAggregate from "./applyOffsetPaginationToMongoAggregate.js";
+
+let mockCollection, mockPipeline;
+beforeEach(() => {
+  mockCollection = getFakeMongoCollection("Test", new Array(100), {});
+  mockPipeline = [{ "$someOperator": "someParameter" }]; // TODO: Implement real MongoDB test library to use actual pipelines
+});
+
+test("without first limits to first 20", async () => {
+  mockCollection.aggregate.count.mockReturnValueOnce(Promise.resolve(30));
+  mockCollection.aggregate.hasNext.mockReturnValueOnce(true);
+
+  const result = await applyOffsetPaginationToMongoAggregate(mockCollection, mockPipeline, { offset: 1 });
+
+  expect(result).toEqual({
+    hasNextPage: true,
+    hasPreviousPage: true,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 20
+      },
+      {
+        "$skip": 1
+      }
+    ])
+  });
+});
+
+test("returns hasNextPage correctly when no more items exist", async () => {
+  mockCollection.aggregate.count.mockReturnValueOnce(Promise.resolve(0));
+  mockCollection.aggregate.hasNext.mockReturnValueOnce(false);
+  const result = await applyOffsetPaginationToMongoAggregate(mockCollection, mockPipeline, { offset: 1, first: 10 });
+
+  expect(result).toEqual({
+    hasNextPage: false,
+    hasPreviousPage: true,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 10
+      },
+      {
+        "$skip": 1
+      } 
+    ])
+  });
+});

--- a/lib/graphql/applyPaginationToMongoAggregate.js
+++ b/lib/graphql/applyPaginationToMongoAggregate.js
@@ -1,0 +1,90 @@
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Inspired by https://www.reindex.io/blog/relay-graphql-pagination-with-mongodb/
+ * @name applyPaginationToMongoAggregate
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Adds `skip` and `limit` to a MongoDB aggregation pipeline as necessary, based on GraphQL
+ *   `first` and `last` params
+ * @param {MongoDB.Collection} collection MongoDB collection to run the aggregation pipeline on
+ * @param {Array} pipeline MongoDB aggregation pipeline
+ * @param {Object} args An object with `first` or `last` but not both.
+ * @param {Object} options Options
+ * @param {Boolean} [options.includeHasPreviousPage] Whether to return the `pageInfo.hasPreviousPage`.
+ *   Default is `true`. Set this to `false` if you don't need it to avoid an extra database command.
+ * @param {Boolean} [options.includeHasNextPage] Whether to return the `pageInfo.hasNextPage`.
+ *   Default is `true`. Set this to `false` if you don't need it to avoid an extra database command.
+ * @returns {Promise<Object>} `{ hasNextPage, hasPreviousPage, pipeline }`
+ */
+export default async function applyPaginationToMongoAggregate(collection, pipeline, { first, last } = {}, {
+  includeHasNextPage = true,
+  includeHasPreviousPage = true
+} = {}) {
+  if (first && last) throw new Error("Request either `first` or `last` but not both");
+
+  // Enforce a `first: 20` limit if no user-supplied limit, using the DEFAULT_LIMIT
+  const limit = first || last || DEFAULT_LIMIT;
+
+  let skip = 0;
+
+  let hasNextPage = null;
+  let hasPreviousPage = null;
+
+  if (last) {
+    // Get the new count after applying before/after
+    const totalCount = await collection.aggregate(pipeline).count();
+    if (totalCount > last) {
+      skip = totalCount - last;
+    }
+
+    if (includeHasPreviousPage) {
+      if (skip === 0) {
+        hasPreviousPage = false;
+      } else {
+        // For backward pagination, we can find out whether there is a previous page here, but we can't
+        // find out whether there's a next page because the cursor has already had "before" filtering
+        // added. Code external to this function will need to determine whether there are any documents
+        // after that "before" ID.
+        const prevPipeline = [...pipeline];
+        prevPipeline.push({
+          "$limit": limit + 1
+        });
+        prevPipeline.push({
+          "$skip": skip - 1
+        });
+        const prevCursorCount = await collection.aggregate(prevPipeline).count();
+        hasPreviousPage = prevCursorCount > limit;
+      }
+    }
+  } else if (includeHasNextPage) {
+    // For forward pagination, we can find out whether there is a next page here, but we can't
+    // find out whether there's a previous page because the cursor has already had "after" filtering
+    // added. Code external to this function will need to determine whether there are any documents
+    // before that "after" ID.
+    const nextPipeline = [...pipeline];
+    nextPipeline.push({
+      "$limit": limit + 1
+    });
+    const nextCursorCount = await collection.aggregate(nextPipeline).count();
+    hasNextPage = nextCursorCount > limit;
+  }
+
+  // Apply limit + skip to the provided pipeline
+  pipeline.push({
+    "$limit": limit
+  });
+
+  if (skip) {
+    pipeline.push({
+      "$skip": skip
+    });
+  }
+
+  return {
+    hasNextPage,
+    hasPreviousPage,
+    pipeline
+  };
+}
+

--- a/lib/graphql/applyPaginationToMongoAggregate.test.js
+++ b/lib/graphql/applyPaginationToMongoAggregate.test.js
@@ -1,0 +1,107 @@
+import getFakeMongoCollection from "../tests/getFakeMongoCollection.js";
+import applyPaginationToMongoAggregate from "./applyPaginationToMongoAggregate.js";
+
+let mockCollection, mockPipeline;
+beforeEach(() => {
+  mockCollection = getFakeMongoCollection("Test", new Array(100));
+  mockPipeline = [{ "$someOperator": "someParameter" }];
+});
+
+test("with neither first nor last limits to first 20", async () => {
+  mockCollection.aggregate.count.mockReturnValueOnce(Promise.resolve(21));
+  const result = await applyPaginationToMongoAggregate(mockCollection, mockPipeline, undefined);
+  expect(result).toEqual({
+    hasNextPage: true,
+    hasPreviousPage: null,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 20
+      }
+    ])
+  });
+});
+
+test("with both first and last, throws error", () => {
+  expect(applyPaginationToMongoAggregate(mockCollection, mockPipeline, { first: 1, last: 1 })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("with first and more, returns hasNextPage true", async () => {
+  mockCollection.aggregate.count.mockReturnValueOnce(Promise.resolve(51));
+  const result = await applyPaginationToMongoAggregate(mockCollection, mockPipeline, { first: 50 });
+  expect(result).toEqual({
+    hasNextPage: true,
+    hasPreviousPage: null,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 50
+      }
+    ])
+  });
+});
+
+test("with first and no more, returns hasNextPage false", async () => {
+  mockCollection.aggregate.count.mockReturnValueOnce(Promise.resolve(50));
+  const result = await applyPaginationToMongoAggregate(mockCollection, mockPipeline, { first: 50 });
+  expect(result).toEqual({
+    hasNextPage: false,
+    hasPreviousPage: null,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 50
+      }
+    ])
+  });
+});
+
+test("with last and more, returns hasPreviousPage true", async () => {
+  mockCollection.aggregate.count
+    .mockReturnValueOnce(Promise.resolve(80))
+    .mockReturnValueOnce(Promise.resolve(51));
+  const result = await applyPaginationToMongoAggregate(mockCollection, mockPipeline, { last: 50 });
+  expect(result).toEqual({
+    hasNextPage: null,
+    hasPreviousPage: true,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 50
+      },
+      {
+        "$skip": 30
+      }
+    ])
+  });
+});
+
+test("with last and no more, returns hasPreviousPage false", async () => {
+  mockCollection.aggregate.count
+    .mockReturnValueOnce(Promise.resolve(80))
+    .mockReturnValueOnce(Promise.resolve(50));
+  const result = await applyPaginationToMongoAggregate(mockCollection, mockPipeline, { last: 50 });
+  expect(result).toEqual({
+    hasNextPage: null,
+    hasPreviousPage: false,
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$limit": 50
+      },
+      {
+        "$skip": 30
+      }
+    ])
+  });
+});

--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -28,7 +28,11 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
   includeHasPreviousPage = true,
   includeTotalCount = true
 } = {}) {
-  const { offset, last, sortBy, sortOrder } = args;
+  const { after, before, last, offset, sortBy, sortOrder } = args;
+
+  if (after !== undefined || before !== undefined) {
+    throw new Error("Connection args `after` and `before` aren't supported by getPaginatedResponseFromAggregate");
+  }
 
   // Get the total count, prior to adding before/after filtering
   let totalCount = null;

--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -69,7 +69,7 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
       hasPreviousPage,
       hasNextPage,
       pipeline
-    } = await applyPaginationToMongoAggregate(mongoCursor, args, {
+    } = await applyPaginationToMongoAggregate(collection, pipeline, args, {
       includeHasNextPage,
       includeHasPreviousPage
     }));
@@ -78,10 +78,10 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
   // Figure out proper hasNext/hasPrevious
   const pageInfo = {};
   if (includeHasNextPage) {
-    pageInfo.hasNextPage = hasNextPage === null ? hasMore : hasNextPage;
+    pageInfo.hasNextPage = hasNextPage;
   }
   if (includeHasPreviousPage) {
-    pageInfo.hasPreviousPage = hasPreviousPage === null ? hasMore : hasPreviousPage;
+    pageInfo.hasPreviousPage = hasPreviousPage;
   }
 
   const nodes = await collection.aggregate(pipeline).toArray();

--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -39,7 +39,7 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
           "$sum": 1
         }
       }
-    })
+    });
   }
 
   // Get a MongoDB sort object

--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -1,0 +1,102 @@
+import applyOffsetPaginationToMongoAggregate from "./applyOffsetPaginationToMongoAggregate.js";
+import applyPaginationToMongoAggregate from "./applyPaginationToMongoAggregate.js";
+import getMongoSort from "./getMongoSort.js";
+
+/**
+ * Resolvers that return multiple documents in the form of a connection should construct a
+ * MongoDB aggregation pipeline, pass the pipeline to this function, and then return the result.
+ *
+ * @name getPaginatedResponseFromAggregate
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Given a MongoDB aggregation pipeline, adds skip, limit, sort, and other filters as necessary
+ *   based on GraphQL resolver arguments.
+ * @param {MongoDB.Collection} collection MongoDB collection to run the aggregation pipeline on
+ * @param {Array} pipeline MongoDB aggregation pipeline
+ * @param {Object} args Connection arguments from GraphQL query
+ * @param {Object} options Options
+ * @param {Boolean} [options.includeTotalCount] Whether to return the `totalCount`. Default is `true`. Set this to
+ *   `false` if you don't need it to avoid an extra database command.
+ * @param {Boolean} [options.includeHasPreviousPage] Whether to return the `pageInfo.hasPreviousPage`.
+ *   Default is `true`. Set this to `false` if you don't need it to avoid an extra database command.
+ * @param {Boolean} [options.includeHasNextPage] Whether to return the `pageInfo.hasNextPage`.
+ *   Default is `true`. Set this to `false` if you don't need it to avoid an extra database command.
+ * @returns {Promise<Object>} `{ nodes, pageInfo, totalCount }`
+ */
+async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
+  includeHasNextPage = true,
+  includeHasPreviousPage = true,
+  includeTotalCount = true
+} = {}) {
+  const { offset, last, sortBy, sortOrder } = args;
+
+  // Get the total count, prior to adding before/after filtering
+  let totalCount = null;
+  if (includeTotalCount) {
+    pipeline.push({
+      "$addFields": {
+        totalCount: {
+          "$sum": 1
+        }
+      }
+    })
+  }
+
+  // Get a MongoDB sort object
+  const sort = getMongoSort({ sortBy, sortOrder });
+
+  pipeline.push({
+    "$sort": sort
+  });
+
+  let hasPreviousPage;
+  let hasNextPage;
+
+  if (offset !== undefined) {
+    // offset and last cannot be used together
+    if (last) throw new Error("Request either `last` or `offset` but not both");
+
+    ({
+      hasPreviousPage,
+      hasNextPage,
+      pipeline
+    } = await applyOffsetPaginationToMongoAggregate(collection, pipeline, args, {
+      includeHasNextPage
+    }));
+  } else {
+    // Skip calculating pageInfo if it wasn't requested. Saves a db count command.
+    ({
+      hasPreviousPage,
+      hasNextPage,
+      pipeline
+    } = await applyPaginationToMongoAggregate(mongoCursor, args, {
+      includeHasNextPage,
+      includeHasPreviousPage
+    }));
+  }
+
+  // Figure out proper hasNext/hasPrevious
+  const pageInfo = {};
+  if (includeHasNextPage) {
+    pageInfo.hasNextPage = hasNextPage === null ? hasMore : hasNextPage;
+  }
+  if (includeHasPreviousPage) {
+    pageInfo.hasPreviousPage = hasPreviousPage === null ? hasMore : hasPreviousPage;
+  }
+
+  const nodes = await collection.aggregate(pipeline).toArray();
+  const count = nodes.length;
+  if (count) {
+    pageInfo.startCursor = nodes[0]._id;
+    pageInfo.endCursor = nodes[count - 1]._id;
+
+    if (includeTotalCount) {
+      totalCount = nodes[0].totalCount;
+    }
+  }
+
+  return { nodes, pageInfo, totalCount };
+}
+
+export default getPaginatedResponseFromAggregate;
+

--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -95,7 +95,7 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
     }
   }
 
-  return { nodes, pageInfo, totalCount };
+  return { pipeline, nodes, pageInfo, totalCount };
 }
 
 export default getPaginatedResponseFromAggregate;

--- a/lib/graphql/getPaginatedResponseFromAggregate.test.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.test.js
@@ -25,6 +25,20 @@ afterAll(() => {
   restore$getMongoSort();
 });
 
+test("throws error when using `after` connection arg", async () => {
+  await expect(getPaginatedResponseFromAggregate(mockCollection, mockPipeline, {
+    ...mockArgs,
+    after: "someCursor"
+  })).rejects.toThrow(Error);
+});
+
+test("throws error when using `before` connection arg", async () => {
+  await expect(getPaginatedResponseFromAggregate(mockCollection, mockPipeline, {
+    ...mockArgs,
+    before: "someCursor"
+  })).rejects.toThrow(Error);
+});
+
 test("calls getMongoSort with correct args", async () => {
   await getPaginatedResponseFromAggregate(mockCollection, mockPipeline, mockArgs);
   expect(getMongoSortMock).toHaveBeenCalledWith({

--- a/lib/graphql/getPaginatedResponseFromAggregate.test.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.test.js
@@ -1,0 +1,58 @@
+import getFakeMongoCollection from "../tests/getFakeMongoCollection.js";
+import getPaginatedResponseFromAggregate from "./getPaginatedResponseFromAggregate.js";
+import {
+  restore as restore$applyPaginationToMongoAggregate,
+  rewire as rewire$applyPaginationToMongoAggregate
+} from "./applyPaginationToMongoAggregate.js";
+import { restore as restore$getMongoSort, rewire as rewire$getMongoSort } from "./getMongoSort.js";
+
+const baseQuery = { _id: "BASE_QUERY" };
+const mockCollection = getFakeMongoCollection("COLLECTIONss", ["1", "2", "3", "4", "5"], { query: baseQuery });
+const mockPipeline = [{ "$someOperator": "someParameter" }];
+const applyPaginationToMongoAggregateMock = jest
+  .fn()
+  .mockName("applyPaginationToMongoAggregate")
+  .mockReturnValue({ hasNextPage: true, hasPreviousPage: null });
+const getMongoSortMock = jest.fn().mockName("getMongoSort");
+
+const mockArgs = { sortOrder: "asc", sortBy: "name" };
+
+beforeAll(() => {
+  rewire$applyPaginationToMongoAggregate(applyPaginationToMongoAggregateMock);
+  rewire$getMongoSort(getMongoSortMock);
+});
+
+afterAll(() => {
+  restore$applyPaginationToMongoAggregate();
+  restore$getMongoSort();
+});
+
+test("calls applyPaginationToMongoAggregate with mongo cursor and args", async () => {
+  await getPaginatedResponseFromAggregate(mockCollection, mockPipeline, mockArgs);
+  expect(applyPaginationToMongoAggregateMock).toHaveBeenCalledWith(mockCollection, mockArgs, {
+    includeHasNextPage: true,
+    includeHasPreviousPage: true
+  });
+});
+
+test("calls getMongoSort with correct args", async () => {
+  await getPaginatedResponseFromAggregate(mockCollection, mockArgs);
+  expect(getMongoSortMock).toHaveBeenCalledWith({
+    sortBy: mockArgs.sortBy,
+    sortOrder: mockArgs.sortOrder
+  });
+});
+
+test("applies filter and sort and returns correct result", async () => {
+  const nodes = [{ _id: "123start" }, { _id: "123end" }];
+  getMongoSortMock.mockReturnValueOnce("SORT");
+  mockCollection.toArray.mockReturnValueOnce(nodes);
+  const result = await getPaginatedResponseFromAggregate(mockCollection, mockArgs);
+  expect(mockCollection.filter).toHaveBeenCalledWith("FILTER");
+  expect(mockCollection.sort).toHaveBeenCalledWith("SORT");
+  expect(result).toEqual({
+    nodes,
+    pageInfo: { endCursor: "123end", hasNextPage: true, hasPreviousPage: true, startCursor: "123start" },
+    totalCount: 5
+  });
+});

--- a/lib/graphql/getPaginatedResponseFromAggregate.test.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.test.js
@@ -6,53 +6,58 @@ import {
 } from "./applyPaginationToMongoAggregate.js";
 import { restore as restore$getMongoSort, rewire as rewire$getMongoSort } from "./getMongoSort.js";
 
-const baseQuery = { _id: "BASE_QUERY" };
-const mockCollection = getFakeMongoCollection("COLLECTIONss", ["1", "2", "3", "4", "5"], { query: baseQuery });
-const mockPipeline = [{ "$someOperator": "someParameter" }];
-const applyPaginationToMongoAggregateMock = jest
-  .fn()
-  .mockName("applyPaginationToMongoAggregate")
-  .mockReturnValue({ hasNextPage: true, hasPreviousPage: null });
+const mockCollection = getFakeMongoCollection("SomeCollection", ["1", "2", "3", "4", "5"]);
 const getMongoSortMock = jest.fn().mockName("getMongoSort");
 
 const mockArgs = { sortOrder: "asc", sortBy: "name" };
 
+let mockPipeline;
+
 beforeAll(() => {
-  rewire$applyPaginationToMongoAggregate(applyPaginationToMongoAggregateMock);
   rewire$getMongoSort(getMongoSortMock);
 });
 
+beforeEach(() => {
+  mockPipeline = [{ "$someOperator": "someParameter" }];
+});
+
 afterAll(() => {
-  restore$applyPaginationToMongoAggregate();
   restore$getMongoSort();
 });
 
-test("calls applyPaginationToMongoAggregate with mongo cursor and args", async () => {
-  await getPaginatedResponseFromAggregate(mockCollection, mockPipeline, mockArgs);
-  expect(applyPaginationToMongoAggregateMock).toHaveBeenCalledWith(mockCollection, mockArgs, {
-    includeHasNextPage: true,
-    includeHasPreviousPage: true
-  });
-});
-
 test("calls getMongoSort with correct args", async () => {
-  await getPaginatedResponseFromAggregate(mockCollection, mockArgs);
+  await getPaginatedResponseFromAggregate(mockCollection, mockPipeline, mockArgs);
   expect(getMongoSortMock).toHaveBeenCalledWith({
     sortBy: mockArgs.sortBy,
     sortOrder: mockArgs.sortOrder
   });
 });
 
-test("applies filter and sort and returns correct result", async () => {
+test("includes sort param in pipeline and returns correct result", async () => {
   const nodes = [{ _id: "123start" }, { _id: "123end" }];
   getMongoSortMock.mockReturnValueOnce("SORT");
-  mockCollection.toArray.mockReturnValueOnce(nodes);
-  const result = await getPaginatedResponseFromAggregate(mockCollection, mockArgs);
-  expect(mockCollection.filter).toHaveBeenCalledWith("FILTER");
-  expect(mockCollection.sort).toHaveBeenCalledWith("SORT");
+  mockCollection.aggregate.toArray.mockReturnValueOnce(nodes);
+  const result = await getPaginatedResponseFromAggregate(mockCollection, mockPipeline, mockArgs);
   expect(result).toEqual({
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$addFields": {
+          totalCount: {
+            "$sum": 1
+          }
+        }
+      },
+      {
+        "$sort": "SORT"
+      },
+      {
+        "$limit": 20
+      }
+    ]),
     nodes,
-    pageInfo: { endCursor: "123end", hasNextPage: true, hasPreviousPage: true, startCursor: "123start" },
-    totalCount: 5
+    pageInfo: { endCursor: "123end", hasNextPage: false, hasPreviousPage: null, startCursor: "123start" }
   });
 });

--- a/lib/tests/getFakeMongoCollection.js
+++ b/lib/tests/getFakeMongoCollection.js
@@ -1,0 +1,34 @@
+/**
+ * Helper functions for use in Jest tests
+ * @namespace TestHelpers
+ */
+
+/**
+ * @name getFakeMongoCollection
+ * @method
+ * @memberof TestHelpers
+ * @param {String} collectionName - name of the collection
+ * @param {Any} aggregateResults - aggregateResults to be returned as part of the collection
+ * @param {Object} options - options to pass to the query
+ * @returns {Object} fake collection
+ */
+export default function getFakeMongoCollection(collectionName, aggregateResults, options) {
+  const collection = {};
+
+  const isTesting = typeof jest !== "undefined";
+
+  if (isTesting) {
+    collection.aggregate = jest.fn().mockName("collection.aggregate").mockImplementation(() => collection.aggregate);
+    collection.aggregate.count = jest.fn().mockName("collection.aggregate.count").mockReturnValue(aggregateResults.length);
+    collection.aggregate.hasNext = jest.fn().mockName("collection.aggregate.hasNext").mockResolvedValue(false);
+    collection.aggregate.apply = jest.fn().mockName("collection.aggregate.apply").mockReturnValue(collection);
+
+  } else {
+    collection.aggregate = () => collection.aggregate;
+    collection.aggregate.count = () => aggregateResults.length;
+    collection.aggregate.hasNext = () => Promise.resolve(false);
+    collection.aggregate.apply = () => collection;
+  }
+
+  return collection;
+}

--- a/lib/tests/getFakeMongoCollection.js
+++ b/lib/tests/getFakeMongoCollection.js
@@ -22,12 +22,13 @@ export default function getFakeMongoCollection(collectionName, aggregateResults,
     collection.aggregate.count = jest.fn().mockName("collection.aggregate.count").mockReturnValue(aggregateResults.length);
     collection.aggregate.hasNext = jest.fn().mockName("collection.aggregate.hasNext").mockResolvedValue(false);
     collection.aggregate.apply = jest.fn().mockName("collection.aggregate.apply").mockReturnValue(collection);
-
+    collection.aggregate.toArray = jest.fn().mockName("collection.aggregate.toArray").mockReturnValue(aggregateResults);
   } else {
     collection.aggregate = () => collection.aggregate;
     collection.aggregate.count = () => aggregateResults.length;
     collection.aggregate.hasNext = () => Promise.resolve(false);
     collection.aggregate.apply = () => collection;
+    collection.aggregate.toArray = () => aggregateResults;
   }
 
   return collection;


### PR DESCRIPTION
Resolves #16 by adding a new `getPaginatedResponseFromAggregate` and corresponding pagination functions.

`getPaginatedResponseFromAggregate` itself is working, but I'm still thinking about how to best test it. Should I mock a MongoDB aggregate cursor? Or maybe we could think of using an in-memory MongoDB instance, which would make more sense to test it against the real API?