### PR TITLE
feat: add insertPrimaryShop test fn

### DIFF
--- a/lib/tests/insertPrimaryShop.js
+++ b/lib/tests/insertPrimaryShop.js
@@ -1,0 +1,129 @@
+import Random from "@reactioncommerce/random";
+
+const mockShop = {
+  allowGuestCheckout: false,
+  slug: "mockSlug",
+  merchantShops: [ { _id: "mock_id", slug: "mockSlug", name: "mockName" } ],
+  shopType: "primary",
+  active: true,
+  status: "mockStatus",
+  name: "Primary Shop",
+  description: "mockDescription",
+  keywords: "mockKeywords",
+  addressBook: [
+    {
+      _id: "mock_id",
+      fullName: "mockFullName",
+      firstName: "mockFirstName",
+      lastName: "mockLastName",
+      address1: "mockAddress1",
+      address2: "mockAddress2",
+      addressName: "mockAddressName",
+      city: "mockCity",
+      company: "mockCompany",
+      phone: "mockPhone",
+      region: "mockRegion",
+      postal: "mockPostal",
+      country: "mockCountry",
+      isCommercial: false,
+      isBillingDefault: true,
+      isShippingDefault: false,
+      failedValidation: true,
+      metafields: []
+    }
+  ],
+  domains: [ "mockDomains.$" ],
+  emails: [
+    {
+      provides: "mockProvides",
+      address: "Deborah37@yahoo.com",
+      verified: false
+    }
+  ],
+  defaultPaymentMethod: "mockDefaultPaymentMethod",
+  currency: "USD",
+  currencies: {},
+  locales: { continents: {}, countries: {} },
+  language: "en",
+  languages: [ { label: "mockLabel", i18n: "mockI18n", enabled: false } ],
+  public: "mockPublic",
+  timezone: "mockTimezone",
+  baseUOL: "mockBaseUOL",
+  unitsOfLength: [
+    {
+      uol: "mockUnitsOfLength.$.uol",
+      label: "mockUnitsOfLength.$.label",
+      default: false
+    }
+  ],
+  baseUOM: "mockBaseUOM",
+  unitsOfMeasure: [
+    {
+      uom: "mockUnitsOfMeasure.$.uom",
+      label: "mockUnitsOfMeasure.$.label",
+      default: false
+    }
+  ],
+  metafields: [
+    {
+      key: "mockKey",
+      namespace: "mockNamespace",
+      scope: "mockScope",
+      value: "mockValue",
+      valueType: "mockValueType",
+      description: "mockDescription"
+    }
+  ],
+  defaultSellerRoles: [ "mockDefaultSellerRoles.$" ],
+  defaultParcelSize: { weight: 45053, height: 32953, length: 23919, width: 93407 },
+  theme: { themeId: "mockThemeId", styles: "mockStyles" },
+  brandAssets: [ { mediaId: "mockMediaId", type: "mockType" } ],
+  paymentMethods: [ {} ],
+  availablePaymentMethods: [ "mockAvailablePaymentMethods.$" ],
+  workflow: { status: "mockStatus", workflow: [ "mockWorkflow.$" ] },
+  defaultNavigationTreeId: "mockDefaultNavigationTreeId",
+  shopLogoUrls: { primaryShopLogoUrl: "mockPrimaryShopLogoUrl" },
+  storefrontUrls: {
+    storefrontHomeUrl: "mockStorefrontHomeUrl",
+    storefrontLoginUrl: "mockStorefrontLoginUrl",
+    storefrontOrderUrl: "mockStorefrontOrderUrl",
+    storefrontOrdersUrl: "mockStorefrontOrdersUrl",
+    storefrontAccountProfileUrl: "mockStorefrontAccountProfileUrl"
+  },
+  allowCustomUserLocale: true,
+  orderStatusLabels: {}
+};
+
+/**
+ * @name insertPrimaryShop
+ * @summary Inserts a primary shop with mock data for use in integration tests
+ * @param {Object} context App context
+ * @param {Object} [shopData] Optional shop data to override the defaults
+ * @param {Object} [options] Other info
+ * @param {String} [options.userId=null] User ID to use as `createdBy`
+ * @returns {Object} fake cursor
+ */
+export default async function insertPrimaryShop(context, shopData, options = {}) {
+  const { appEvents, collections } = context;
+
+  const newId = (shopData && shopData._id) || Random.id();
+  const createdAt = new Date();
+
+  const primaryShop = {
+    ...mockShop,
+    createdAt,
+    updatedAt: createdAt,
+    ...(shopData || {}),
+    _id: newId,
+    shopType: "primary"
+  };
+
+  const result = await collections.Shops.insertOne(primaryShop);
+
+  await appEvents.emit("afterShopCreate", {
+    createdBy: options.userId || null,
+    shop: primaryShop
+  });
+
+  return newId;
+}

--- a/lib/tests/insertPrimaryShop.js
+++ b/lib/tests/insertPrimaryShop.js
@@ -3,7 +3,7 @@ import Random from "@reactioncommerce/random";
 const mockShop = {
   allowGuestCheckout: false,
   slug: "mockSlug",
-  merchantShops: [ { _id: "mock_id", slug: "mockSlug", name: "mockName" } ],
+  merchantShops: [{ _id: "mock_id", slug: "mockSlug", name: "mockName" }],
   shopType: "primary",
   active: true,
   status: "mockStatus",
@@ -32,7 +32,7 @@ const mockShop = {
       metafields: []
     }
   ],
-  domains: [ "mockDomains.$" ],
+  domains: ["mockDomains.$"],
   emails: [
     {
       provides: "mockProvides",
@@ -45,7 +45,7 @@ const mockShop = {
   currencies: {},
   locales: { continents: {}, countries: {} },
   language: "en",
-  languages: [ { label: "mockLabel", i18n: "mockI18n", enabled: false } ],
+  languages: [{ label: "mockLabel", i18n: "mockI18n", enabled: false }],
   public: "mockPublic",
   timezone: "mockTimezone",
   baseUOL: "mockBaseUOL",
@@ -74,13 +74,13 @@ const mockShop = {
       description: "mockDescription"
     }
   ],
-  defaultSellerRoles: [ "mockDefaultSellerRoles.$" ],
+  defaultSellerRoles: ["mockDefaultSellerRoles.$"],
   defaultParcelSize: { weight: 45053, height: 32953, length: 23919, width: 93407 },
   theme: { themeId: "mockThemeId", styles: "mockStyles" },
-  brandAssets: [ { mediaId: "mockMediaId", type: "mockType" } ],
-  paymentMethods: [ {} ],
-  availablePaymentMethods: [ "mockAvailablePaymentMethods.$" ],
-  workflow: { status: "mockStatus", workflow: [ "mockWorkflow.$" ] },
+  brandAssets: [{ mediaId: "mockMediaId", type: "mockType" }],
+  paymentMethods: [{}],
+  availablePaymentMethods: ["mockAvailablePaymentMethods.$"],
+  workflow: { status: "mockStatus", workflow: ["mockWorkflow.$"] },
   defaultNavigationTreeId: "mockDefaultNavigationTreeId",
   shopLogoUrls: { primaryShopLogoUrl: "mockPrimaryShopLogoUrl" },
   storefrontUrls: {
@@ -118,7 +118,7 @@ export default async function insertPrimaryShop(context, shopData, options = {})
     shopType: "primary"
   };
 
-  const result = await collections.Shops.insertOne(primaryShop);
+  await collections.Shops.insertOne(primaryShop);
 
   await appEvents.emit("afterShopCreate", {
     createdBy: options.userId || null,

--- a/lib/tests/insertPrimaryShop.test.js
+++ b/lib/tests/insertPrimaryShop.test.js
@@ -1,0 +1,154 @@
+import insertPrimaryShop from "./insertPrimaryShop.js";
+import mockContext from "./mockContext.js";
+
+const expectedShopBase = {
+  allowGuestCheckout: false,
+  slug: "mockSlug",
+  merchantShops: [ { _id: "mock_id", slug: "mockSlug", name: "mockName" } ],
+  shopType: "primary",
+  active: true,
+  status: "mockStatus",
+  name: "Primary Shop",
+  description: "mockDescription",
+  keywords: "mockKeywords",
+  addressBook: [
+    {
+      _id: "mock_id",
+      fullName: "mockFullName",
+      firstName: "mockFirstName",
+      lastName: "mockLastName",
+      address1: "mockAddress1",
+      address2: "mockAddress2",
+      addressName: "mockAddressName",
+      city: "mockCity",
+      company: "mockCompany",
+      phone: "mockPhone",
+      region: "mockRegion",
+      postal: "mockPostal",
+      country: "mockCountry",
+      isCommercial: false,
+      isBillingDefault: true,
+      isShippingDefault: false,
+      failedValidation: true,
+      metafields: []
+    }
+  ],
+  domains: [ "mockDomains.$" ],
+  emails: [
+    {
+      provides: "mockProvides",
+      address: "Deborah37@yahoo.com",
+      verified: false
+    }
+  ],
+  defaultPaymentMethod: "mockDefaultPaymentMethod",
+  currency: "USD",
+  currencies: {},
+  locales: { continents: {}, countries: {} },
+  language: "en",
+  languages: [ { label: "mockLabel", i18n: "mockI18n", enabled: false } ],
+  public: "mockPublic",
+  timezone: "mockTimezone",
+  baseUOL: "mockBaseUOL",
+  unitsOfLength: [
+    {
+      uol: "mockUnitsOfLength.$.uol",
+      label: "mockUnitsOfLength.$.label",
+      default: false
+    }
+  ],
+  baseUOM: "mockBaseUOM",
+  unitsOfMeasure: [
+    {
+      uom: "mockUnitsOfMeasure.$.uom",
+      label: "mockUnitsOfMeasure.$.label",
+      default: false
+    }
+  ],
+  metafields: [
+    {
+      key: "mockKey",
+      namespace: "mockNamespace",
+      scope: "mockScope",
+      value: "mockValue",
+      valueType: "mockValueType",
+      description: "mockDescription"
+    }
+  ],
+  defaultSellerRoles: [ "mockDefaultSellerRoles.$" ],
+  defaultParcelSize: { weight: 45053, height: 32953, length: 23919, width: 93407 },
+  theme: { themeId: "mockThemeId", styles: "mockStyles" },
+  brandAssets: [ { mediaId: "mockMediaId", type: "mockType" } ],
+  paymentMethods: [ {} ],
+  availablePaymentMethods: [ "mockAvailablePaymentMethods.$" ],
+  workflow: { status: "mockStatus", workflow: [ "mockWorkflow.$" ] },
+  defaultNavigationTreeId: "mockDefaultNavigationTreeId",
+  shopLogoUrls: { primaryShopLogoUrl: "mockPrimaryShopLogoUrl" },
+  storefrontUrls: {
+    storefrontHomeUrl: "mockStorefrontHomeUrl",
+    storefrontLoginUrl: "mockStorefrontLoginUrl",
+    storefrontOrderUrl: "mockStorefrontOrderUrl",
+    storefrontOrdersUrl: "mockStorefrontOrdersUrl",
+    storefrontAccountProfileUrl: "mockStorefrontAccountProfileUrl"
+  },
+  allowCustomUserLocale: true,
+  orderStatusLabels: {}
+};
+
+test("inserts a primary shop with random string ID", async () => {
+  const shopId = await insertPrimaryShop(mockContext);
+
+  const expectedShop = {
+    ...expectedShopBase,
+    _id: jasmine.any(String),
+    createdAt: jasmine.any(Date),
+    updatedAt: jasmine.any(Date)
+  }
+
+  expect(shopId).toEqual(jasmine.any(String));
+  expect(mockContext.collections.Shops.insertOne).toHaveBeenCalledWith(expectedShop);
+  expect(mockContext.appEvents.emit).toHaveBeenCalledWith("afterShopCreate", {
+    createdBy: null,
+    shop: expectedShop
+  });
+});
+
+test("accepts override values for shop fields, including _id, createdAt, and updatedAt", async () => {
+  const overrides = {
+    _id: "CUSTOM_ID",
+    active: false,
+    additionalField: "foo",
+    createdAt: new Date(Date.now() - 300000),
+    updatedAt: new Date()
+  };
+
+  const shopId = await insertPrimaryShop(mockContext, overrides);
+
+  const expectedShop = {
+    ...expectedShopBase,
+    ...overrides
+  };
+
+  expect(shopId).toEqual("CUSTOM_ID");
+  expect(mockContext.collections.Shops.insertOne).toHaveBeenCalledWith(expectedShop);
+  expect(mockContext.appEvents.emit).toHaveBeenCalledWith("afterShopCreate", {
+    createdBy: null,
+    shop: expectedShop
+  });
+});
+
+test("uses provided user ID when emitting", async () => {
+  await insertPrimaryShop(mockContext, null, { userId: "USER" });
+
+  const expectedShop = {
+    ...expectedShopBase,
+    _id: jasmine.any(String),
+    createdAt: jasmine.any(Date),
+    updatedAt: jasmine.any(Date)
+  }
+
+  expect(mockContext.appEvents.emit).toHaveBeenCalledWith("afterShopCreate", {
+    createdBy: "USER",
+    shop: expectedShop
+  });
+});

--- a/lib/tests/insertPrimaryShop.test.js
+++ b/lib/tests/insertPrimaryShop.test.js
@@ -4,7 +4,7 @@ import mockContext from "./mockContext.js";
 const expectedShopBase = {
   allowGuestCheckout: false,
   slug: "mockSlug",
-  merchantShops: [ { _id: "mock_id", slug: "mockSlug", name: "mockName" } ],
+  merchantShops: [{ _id: "mock_id", slug: "mockSlug", name: "mockName" }],
   shopType: "primary",
   active: true,
   status: "mockStatus",
@@ -33,7 +33,7 @@ const expectedShopBase = {
       metafields: []
     }
   ],
-  domains: [ "mockDomains.$" ],
+  domains: ["mockDomains.$"],
   emails: [
     {
       provides: "mockProvides",
@@ -46,7 +46,7 @@ const expectedShopBase = {
   currencies: {},
   locales: { continents: {}, countries: {} },
   language: "en",
-  languages: [ { label: "mockLabel", i18n: "mockI18n", enabled: false } ],
+  languages: [{ label: "mockLabel", i18n: "mockI18n", enabled: false }],
   public: "mockPublic",
   timezone: "mockTimezone",
   baseUOL: "mockBaseUOL",
@@ -75,13 +75,13 @@ const expectedShopBase = {
       description: "mockDescription"
     }
   ],
-  defaultSellerRoles: [ "mockDefaultSellerRoles.$" ],
+  defaultSellerRoles: ["mockDefaultSellerRoles.$"],
   defaultParcelSize: { weight: 45053, height: 32953, length: 23919, width: 93407 },
   theme: { themeId: "mockThemeId", styles: "mockStyles" },
-  brandAssets: [ { mediaId: "mockMediaId", type: "mockType" } ],
-  paymentMethods: [ {} ],
-  availablePaymentMethods: [ "mockAvailablePaymentMethods.$" ],
-  workflow: { status: "mockStatus", workflow: [ "mockWorkflow.$" ] },
+  brandAssets: [{ mediaId: "mockMediaId", type: "mockType" }],
+  paymentMethods: [{}],
+  availablePaymentMethods: ["mockAvailablePaymentMethods.$"],
+  workflow: { status: "mockStatus", workflow: ["mockWorkflow.$"] },
   defaultNavigationTreeId: "mockDefaultNavigationTreeId",
   shopLogoUrls: { primaryShopLogoUrl: "mockPrimaryShopLogoUrl" },
   storefrontUrls: {
@@ -103,7 +103,7 @@ test("inserts a primary shop with random string ID", async () => {
     _id: jasmine.any(String),
     createdAt: jasmine.any(Date),
     updatedAt: jasmine.any(Date)
-  }
+  };
 
   expect(shopId).toEqual(jasmine.any(String));
   expect(mockContext.collections.Shops.insertOne).toHaveBeenCalledWith(expectedShop);
@@ -145,7 +145,7 @@ test("uses provided user ID when emitting", async () => {
     _id: jasmine.any(String),
     createdAt: jasmine.any(Date),
     updatedAt: jasmine.any(Date)
-  }
+  };
 
   expect(mockContext.appEvents.emit).toHaveBeenCalledWith("afterShopCreate", {
     createdBy: "USER",

--- a/lib/tests/mockContext.js
+++ b/lib/tests/mockContext.js
@@ -3,8 +3,8 @@ import mockCollection from "./mockCollection.js";
 const mockContext = {
   accountId: "FAKE_ACCOUNT_ID",
   appEvents: {
-    emit() { },
-    on() { }
+    emit: jest.fn().mockName("appEvents.emit"),
+    on: jest.fn().mockName("appEvents.on")
   },
   collections: {},
   getAbsoluteUrl: jest.fn().mockName("getAbsoluteUrl").mockImplementation((path) => {


### PR DESCRIPTION
Moved the `insertPrimaryShop` function out of `TestApp` instance and over to this package in the `tests` folder, and added unit tests for it. This is prep work for moving `TestApp` to its own NPM package next.