### PR TITLE
feat: add tagsForCatalogProducts function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # api-utils
 
-
 [![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-utils.svg)](https://www.npmjs.com/package/@reactioncommerce/api-utils)
 [![CircleCI](https://circleci.com/gh/reactioncommerce/api-utils.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-utils)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
@@ -22,6 +21,8 @@ Import API util functions in the file you wish to use them in
 ```js
 import functionName from "@reactioncommerce/api-utils/functionName.js";
 ```
+
+Refer to [package docs](https://github.com/reactioncommerce/api-utils/tree/trunk/docs) for a list of available functions.
 
 ## Releases
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@
 
 - [getAbsoluteUrl](./getAbsoluteUrl.md)
 - [getPaginatedResponseFromAggregate](./getPaginatedResponseFromAggregate.md)
+- [tagsForCatalogProducts](./tagsForCatalogProducts.md)

--- a/docs/tagsForCatalogProducts.md
+++ b/docs/tagsForCatalogProducts.md
@@ -1,0 +1,62 @@
+# tagsForCatalogProducts
+
+Give an array of CatalogProduct objects, returns an array of tags for each product ID.
+
+Example data set:
+
+```js
+// Tags
+[
+  {
+    _id: "1",
+    name: "ONE"
+  },
+  {
+    _id: "2",
+    name: "TWO"
+  },
+  {
+    _id: "3",
+    name: "THREE"
+  }
+]
+
+// CatalogProducts
+[
+  {
+    product: {
+      productId: "1",
+      tagIds: ["1", "2"]
+    }
+  },
+  {
+    product: {
+      productId: "2",
+      tagIds: ["3"]
+    }
+  }
+]
+```
+
+Usage:
+
+```js
+// Tags is the "Tags" Mongo.Collection
+// `catalogProducts` is an array of CatalogItemProduct from Catalog collection
+const result = await tagsForCatalogProducts(Tags, catalogProducts);
+```
+
+Result will be:
+
+```js
+[
+  {
+    productId: "1",
+    tags: ["ONE", "TWO"]
+  },
+  {
+    productId: "2",
+    tags: ["THREE"]
+  }
+]
+```

--- a/lib/tagsForCatalogProducts.js
+++ b/lib/tagsForCatalogProducts.js
@@ -1,0 +1,32 @@
+/**
+ * @name tagsForCatalogProducts
+ * @summary Finds all tags associated with the provided array of catalog products.
+ * @param {Mongo.Collection} Tags - The Tags Mongo.Collection instance
+ * @param {Array} catalogProducts - An array of products in the Catalog collection.
+ * @returns {Array} - An array of tag names and corresponding product IDs.
+ */
+export default async function tagsForCatalogProducts(Tags, catalogProducts) {
+  const tagIds = catalogProducts.reduce((list, item) => {
+    if (item.product.tagIds) {
+      list.push(...item.product.tagIds);
+    }
+    return list;
+  }, []);
+
+  if (tagIds.length === 0) return [];
+
+  const tags = await Tags.find({ _id: { $in: tagIds } }).toArray();
+
+  return catalogProducts.reduce((list, item) => {
+    if (item.product.tagIds) {
+      list.push({
+        productId: item.product.productId,
+        tags: item.product.tagIds.map((id) => {
+          const foundTag = tags.find((tag) => tag._id === id);
+          return foundTag ? foundTag.name : null;
+        })
+      });
+    }
+    return list;
+  }, []);
+}

--- a/lib/tagsForCatalogProducts.test.js
+++ b/lib/tagsForCatalogProducts.test.js
@@ -1,0 +1,54 @@
+import tagsForCatalogProducts from "./tagsForCatalogProducts.js";
+import mockCollection from "./tests/mockCollection.js";
+
+const Tags = mockCollection("Tags");
+
+test("tagsForCatalogProducts returns correct tag list", async () => {
+  Tags.toArray.mockReturnValueOnce([
+    {
+      _id: "1",
+      name: "ONE"
+    },
+    {
+      _id: "2",
+      name: "TWO"
+    },
+    {
+      _id: "3",
+      name: "THREE"
+    }
+  ]);
+
+  const catalogProducts = [
+    {
+      product: {
+        productId: "1",
+        tagIds: ["1", "2"]
+      }
+    },
+    {
+      product: {
+        productId: "2",
+        tagIds: ["3"]
+      }
+    }
+  ];
+
+  const result = await tagsForCatalogProducts(Tags, catalogProducts);
+
+  expect(result).toEqual([
+    {
+      productId: "1",
+      tags: ["ONE", "TWO"]
+    },
+    {
+      productId: "2",
+      tags: ["THREE"]
+    }
+  ]);
+});
+
+test("tagsForCatalogProducts returns empty array if there are no CatalogProducts", async () => {
+  const result = await tagsForCatalogProducts(Tags, []);
+  expect(result).toEqual([]);
+});


### PR DESCRIPTION
## Changes
Adds a `tagsForCatalogProducts` function, which is moved and adjusted a bit from the `shipments` plugin, where it was called `tagsByIds`. Moving here so that the `surcharges` plugin can also use it.

## Testing
I added unit tests so only code review is necessary.