### PR TITLE
Return totalCount = 0 when no documents returned

### DIFF
--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -101,6 +101,9 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
       // eslint-disable-next-line prefer-destructuring
       totalCount = nodes[0].totalCount;
     }
+  } else if (includeTotalCount) {
+    // if includeTotalCount was requested but we're returning 0 nodes, set it to 0
+    totalCount = 0;
   }
 
   return { pipeline, nodes, pageInfo, totalCount };

--- a/lib/graphql/getPaginatedResponseFromAggregate.test.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.test.js
@@ -72,3 +72,29 @@ test("includes sort param in pipeline and returns correct result", async () => {
     pageInfo: { endCursor: "123end", hasNextPage: false, hasPreviousPage: null, startCursor: "123start" }
   });
 });
+
+test("returns totalCount == 0 when there are no documents", async () => {
+  const nodes = [];
+  mockCollection.aggregate.toArray.mockReturnValueOnce(nodes);
+  const result = await getPaginatedResponseFromAggregate(mockCollection, mockPipeline, mockArgs);
+  expect(result).toEqual({
+    pipeline: expect.arrayContaining([
+      {
+        "$someOperator": "someParameter"
+      },
+      {
+        "$addFields": {
+          totalCount: {
+            "$sum": 1
+          }
+        }
+      },
+      {
+        "$limit": 20
+      }
+    ]),
+    nodes,
+    pageInfo: { hasNextPage: false, hasPreviousPage: null },
+    totalCount: 0
+  });
+});


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #31 

`totalCount` is `null` when no documents are returned. This PR solves this and makes `totalCount` equal `0` in this case.