### PR TITLE
(feat) Add testing for Array types + tests

### DIFF
--- a/lib/operators.js
+++ b/lib/operators.js
@@ -10,5 +10,9 @@ export default {
   gt(varA, varB) { return varA > varB; },
   lt(varA, varB) { return varA < varB; },
   ne(varA, varB) { return varA !== varB; },
-  match(varA, varB) { return RegExp(varB, "ig").test(varA); }
+  match(varA, varB) { return RegExp(varB, "ig").test(varA); },
+  includes(varA, varB) {
+    if (Array.isArray(varA)) return varA.includes(varB);
+    throw TypeError("First argument much be an array");
+  }
 };

--- a/lib/propertyTypes.js
+++ b/lib/propertyTypes.js
@@ -2,12 +2,13 @@
  * @name propertyTypes
  * @constant
  * @memberof Helpers
- * @summary Checks matching via various operators
- * @returns {Boolean} the result of the check
+ * @summary Normalizes values out to various property types
+ * @returns {Boolean|String|Number|Integer|Array}
  */
 export default {
   bool(varA) { return varA.trim().toLowerCase() === "true"; },
   float(varA) { return parseFloat(varA); },
   int(varA) { return parseInt(varA, 10); },
-  string(varA) { return varA; }
+  string(varA) { return varA; },
+  array(varA) { return varA; }
 };

--- a/lib/propertyTypes.js
+++ b/lib/propertyTypes.js
@@ -2,13 +2,12 @@
  * @name propertyTypes
  * @constant
  * @memberof Helpers
- * @summary Normalizes values out to various property types
+ * @summary Converts string values to other types
  * @returns {Boolean|String|Number|Integer|Array}
  */
 export default {
   bool(varA) { return varA.trim().toLowerCase() === "true"; },
   float(varA) { return parseFloat(varA); },
   int(varA) { return parseInt(varA, 10); },
-  string(varA) { return varA; },
-  array(varA) { return varA; }
+  string(varA) { return varA; }
 };

--- a/lib/tests/operators.test.js
+++ b/lib/tests/operators.test.js
@@ -1,60 +1,60 @@
 import operators from "../operators.js";
 
 test("eq operator returns true if second argument is equal to first argument", () => {
-    const result = operators["eq"]("1", "1");
-    expect(result).toBe(true);
+  const result = operators.eq("1", "1");
+  expect(result).toBe(true);
 });
 
 test("eq operator returns false if second argument is not equal to first argument", () => {
-    const result = operators["eq"]("1", "2");
-    expect(result).toBe(false);
+  const result = operators.eq("1", "2");
+  expect(result).toBe(false);
 });
 
 test("ne operator returns true if second argument is not equal to first argument", () => {
-    const result = operators["ne"]("1", "1");
-    expect(result).toBe(false);
+  const result = operators.ne("1", "1");
+  expect(result).toBe(false);
 });
 
 test("ne operator returns false if second argument is equal to first argument", () => {
-    const result = operators["ne"]("1", "2");
-    expect(result).toBe(true);
+  const result = operators.ne("1", "2");
+  expect(result).toBe(true);
 });
 
 test("gt operator returns true if second argument is greater than first argument", () => {
-    const result = operators["gt"](2, 1);
-    expect(result).toBe(true);
+  const result = operators.gt(2, 1);
+  expect(result).toBe(true);
 });
 
 test("gt operator returns false if second argument is not greater than first argument", () => {
-    const result = operators["gt"](1, 2);
-    expect(result).toBe(false);
+  const result = operators.gt(1, 2);
+  expect(result).toBe(false);
 });
 
 // This test also verifies that the test is case insensitive
 test("match operator returns true if first argument is a regex match for the regex in the second argument", () => {
-    const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
-    const regex = /[A-Z]/g;
-    const result = operators["match"](paragraph, regex);
-    expect(result).toBe(true);
+  const paragraph = "The quick brown fox jumps over the lazy dog. It barked.";
+  const regex = /[A-Z]/g;
+  const result = operators.match(paragraph, regex);
+  expect(result).toBe(true);
 });
 
 test("match operator returns false if first argument is not a regex match for the regex in the second argument", () => {
-    const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
-    const regex = /[0-9]/g;
-    const result = operators["match"](paragraph, regex);
-    expect(result).toBe(false);
+  const paragraph = "The quick brown fox jumps over the lazy dog. It barked.";
+  const regex = /[0-9]/g;
+  const result = operators.match(paragraph, regex);
+  expect(result).toBe(false);
 });
 
 test("includes operator returns true if second argument is in first argument", () => {
-    const result = operators["includes"]([1,2,3,4], 1);
-    expect(result).toBe(true);
+  const result = operators.includes([1, 2, 3, 4], 1);
+  expect(result).toBe(true);
 });
 
 test("includes operator returns false if second argument is not in first argument", () => {
-    const result = operators["includes"]([1,2,3,4], 12);
-    expect(result).toBe(false);
+  const result = operators.includes([1, 2, 3, 4], 12);
+  expect(result).toBe(false);
 });
 
 test("includes operator throws error if passed argument of wrong type", () => {
-    expect(() => operators["includes"]("bloop", 12)).toThrow(TypeError);
+  expect(() => operators.includes("bloop", 12)).toThrow(TypeError);
 });

--- a/lib/tests/operators.test.js
+++ b/lib/tests/operators.test.js
@@ -1,0 +1,60 @@
+import operators from "../operators.js";
+
+test("eq operator returns true if second argument is equal to first argument", () => {
+    const result = operators["eq"]("1", "1");
+    expect(result).toBe(true);
+});
+
+test("eq operator returns false if second argument is not equal to first argument", () => {
+    const result = operators["eq"]("1", "2");
+    expect(result).toBe(false);
+});
+
+test("ne operator returns true if second argument is not equal to first argument", () => {
+    const result = operators["ne"]("1", "1");
+    expect(result).toBe(false);
+});
+
+test("ne operator returns false if second argument is equal to first argument", () => {
+    const result = operators["ne"]("1", "2");
+    expect(result).toBe(true);
+});
+
+test("gt operator returns true if second argument is greater than first argument", () => {
+    const result = operators["gt"](2, 1);
+    expect(result).toBe(true);
+});
+
+test("gt operator returns false if second argument is not greater than first argument", () => {
+    const result = operators["gt"](1, 2);
+    expect(result).toBe(false);
+});
+
+// This test also verifies that the test is case insensitive
+test("match operator returns true if first argument is a regex match for the regex in the second argument", () => {
+    const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
+    const regex = /[A-Z]/g;
+    const result = operators["match"](paragraph, regex);
+    expect(result).toBe(true);
+});
+
+test("match operator returns false if first argument is not a regex match for the regex in the second argument", () => {
+    const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
+    const regex = /[0-9]/g;
+    const result = operators["match"](paragraph, regex);
+    expect(result).toBe(false);
+});
+
+test("includes operator returns true if second argument is in first argument", () => {
+    const result = operators["includes"]([1,2,3,4], 1);
+    expect(result).toBe(true);
+});
+
+test("includes operator returns false if second argument is not in first argument", () => {
+    const result = operators["includes"]([1,2,3,4], 12);
+    expect(result).toBe(false);
+});
+
+test("includes operator throws error if passed argument of wrong type", () => {
+    expect(() => operators["includes"]("bloop", 12)).toThrow(TypeError);
+});

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "scripts": {
     "lint": "npm run lint:eslint",
     "lint:eslint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:file": "jest --no-cache --watch --coverage=false"


### PR DESCRIPTION
Adds testing for Array types so that you use tags in rule-sets. Adds tests for all operators. Fixes copy and paste JSDoc for `propertyTypes`

Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>