### PR TITLE
fix: remove jest globals from non test files

### DIFF
--- a/lib/tests/getFakeMongoCollection.js
+++ b/lib/tests/getFakeMongoCollection.js
@@ -1,5 +1,3 @@
-import { jest } from "@jest/globals";
-
 /**
  * Helper functions for use in Jest tests
  * @namespace TestHelpers

--- a/lib/tests/getFakeMongoCursor.js
+++ b/lib/tests/getFakeMongoCursor.js
@@ -1,5 +1,3 @@
-import { jest } from "@jest/globals";
-
 /**
  * Helper functions for use in Jest tests
  * @namespace TestHelpers

--- a/lib/tests/mockCollection.js
+++ b/lib/tests/mockCollection.js
@@ -1,5 +1,3 @@
-import { jest } from "@jest/globals";
-
 /**
  * @summary Returns a mock collection instance with the given name
  * @param {String} collectionName The collection name

--- a/lib/tests/mockContext.js
+++ b/lib/tests/mockContext.js
@@ -1,4 +1,3 @@
-import { jest } from "@jest/globals";
 import mockCollection from "./mockCollection.js";
 
 const mockContext = {


### PR DESCRIPTION
Resolves #40 
Impact: **critical**
Type: **bugfix**

## Issue
Some non-test files like `mockContext.js`  import from `@jest/globals`. While this may work in this repo, it doesn't work when these utils are used in downstream packages.

## Solution

- Remove `@jest/globals` from non-test files

## Breaking changes

none

## Testing
1. check out repo next to your `reaction` repo (Reaction 3.8.0 branch: https://github.com/reactioncommerce/reaction/pull/6253)
2. from your `reaction` directory run `bin/package-link api-utils ../api-utils`
3. Run the app and the tests and verify they pass