### PR TITLE
fix: better checking and passthrough for non-opaque ids

### DIFF
--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -8,16 +8,15 @@
  */
 export default function decodeOpaqueId(opaqueId) {
   if (opaqueId === undefined || opaqueId === null) return null;
-  const buffer = Buffer.from(opaqueId, "base64");
 
-  // As far as I can tell, round-tripping back to base64 is the
-  // only robust way to determine whether it was encoded as base64
-  // in the first place.
-  if (buffer.toString("base64") !== opaqueId) {
-    return { namespace: null, id: opaqueId };
+  const [namespace, id] = Buffer
+    .from(opaqueId, "base64")
+    .toString("utf8")
+    .split(":");
+
+  if (namespace && id) {
+    return { namespace, id };
   }
 
-  const unencoded = buffer.toString("utf8");
-  const [namespace, id] = unencoded.split(":");
-  return { namespace, id };
+  return { namespace: null, id: opaqueId };
 }

--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -12,7 +12,7 @@ export default function decodeOpaqueId(opaqueId) {
   const [namespace, id] = Buffer
     .from(opaqueId, "base64")
     .toString("utf8")
-    .split(":");
+    .split(":", 2);
 
   if (namespace && id) {
     return { namespace, id };


### PR DESCRIPTION
## Issue / solution
Rework logic of `decodeOpaqueId` to try better handle cases where a non-opaque Id needs to be passed through.

## Testing

Tests should pass