### PR TITLE
fix: aggregate offset pagination fixes

### DIFF
--- a/lib/graphql/applyOffsetPaginationToMongoAggregate.js
+++ b/lib/graphql/applyOffsetPaginationToMongoAggregate.js
@@ -21,14 +21,15 @@ export default async function applyOffsetPaginationToMongoAggregate(collection, 
 } = {}) {
   // Enforce a `first: 20` limit if no user-supplied limit, using the DEFAULT_LIMIT
   const limit = first || DEFAULT_LIMIT;
+  const newPipeline = [...pipeline];
 
   // Apply limit + skip to the provided pipeline
-  pipeline.push({
-    "$limit": limit
+  newPipeline.push({
+    "$skip": offset
   });
 
-  pipeline.push({
-    "$skip": offset
+  newPipeline.push({
+    "$limit": limit
   });
 
   let hasNextPage = null;
@@ -36,14 +37,6 @@ export default async function applyOffsetPaginationToMongoAggregate(collection, 
   const hasPreviousPage = offset > 0;
 
   if (includeHasNextPage) {
-    const nextPipeline = [...pipeline];
-    nextPipeline.push({
-      "$skip": offset + limit
-    });
-    nextPipeline.push({
-      "$limit": 1
-    });
-
     const nextCursor = collection.aggregate(pipeline);
     const nextDoc = await nextCursor.hasNext();
     hasNextPage = !!nextDoc;
@@ -52,7 +45,7 @@ export default async function applyOffsetPaginationToMongoAggregate(collection, 
   return {
     hasNextPage,
     hasPreviousPage,
-    pipeline
+    pipeline: newPipeline
   };
 }
 

--- a/lib/graphql/applyOffsetPaginationToMongoAggregate.test.js
+++ b/lib/graphql/applyOffsetPaginationToMongoAggregate.test.js
@@ -23,12 +23,21 @@ test("without first limits to first 20", async () => {
         "$someOperator": "someParameter"
       },
       {
-        "$limit": 20
+        "$skip": 1
       },
       {
-        "$skip": 1
+        "$limit": 20
       }
     ])
+  });
+
+  // Ensure skip comes before limit, otherwise pagination does not work
+  expect(result.pipeline[1]).toEqual({
+    "$skip": 1
+  });
+
+  expect(result.pipeline[2]).toEqual({
+    "$limit": 20
   });
 });
 
@@ -45,11 +54,20 @@ test("returns hasNextPage correctly when no more items exist", async () => {
         "$someOperator": "someParameter"
       },
       {
-        "$limit": 10
+        "$skip": 1
       },
       {
-        "$skip": 1
+        "$limit": 10
       }
     ])
+  });
+
+  // Ensure skip comes before limit, otherwise pagination does not work
+  expect(result.pipeline[1]).toEqual({
+    "$skip": 1
+  });
+
+  expect(result.pipeline[2]).toEqual({
+    "$limit": 10
   });
 });


### PR DESCRIPTION
Issue: #45 
Type: fix
Impact: critical

# Issue
Offset pagination isn't working with mongo aggregations

# Solution
`$skip` must always come before `$limit` pipelines otherwise pagination will not work. The order of operations has been fixed in the PR.

# Test
Test should pass, but it's by no means an indication if the aggregation actually working. 

To be sure it will have to be npm linked to `reaction` and run with the integration tests.