### PR TITLE
fix: Don't assume that scale=0 means "show cents"

### DIFF
--- a/lib/CurrencyDefinitions.js
+++ b/lib/CurrencyDefinitions.js
@@ -77,7 +77,8 @@ export default {
   BIF: {
     format: "%s%v",
     symbol: "$",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   BMD: {
     format: "%v %s",
@@ -114,7 +115,8 @@ export default {
     symbol: "p.",
     decimal: ",",
     thousand: ".",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   BZD: {
     format: "%s%v",
@@ -180,7 +182,8 @@ export default {
   DJF: {
     format: "%v %s",
     symbol: "Fdj",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   DKK: {
     format: "%s%v",
@@ -261,7 +264,8 @@ export default {
   GNF: {
     format: "%v %s",
     symbol: "FG",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   GTQ: {
     format: "%s%v",
@@ -302,7 +306,8 @@ export default {
   JPY: {
     format: "%s%v",
     symbol: "¥",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   KWD: {
     format: "%s%v",
@@ -311,7 +316,8 @@ export default {
   KRW: {
     format: "%s%v",
     symbol: "₩",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   KZT: {
     format: "%v %s",
@@ -409,7 +415,8 @@ export default {
   XAF: {
     format: "%v %s",
     symbol: "CFA",
-    scale: 0
+    scale: 0,
+    showCents: true
   },
   XCD: {
     format: "%s%v",
@@ -418,6 +425,7 @@ export default {
   XOF: {
     format: "%v %s",
     symbol: "CFA",
-    scale: 0
+    scale: 0,
+    showCents: true
   }
 };

--- a/lib/formatMoney.js
+++ b/lib/formatMoney.js
@@ -19,7 +19,7 @@ export default function formatMoney(price, currencyCode = "USD") {
 
   // If there are no decimal places, in the case of the Japanese Yen, we adjust it here.
   let priceToFormat = price;
-  if (currencyInfo.scale === 0) {
+  if (currencyInfo.showCents) {
     priceToFormat = price * 100;
   }
 


### PR DESCRIPTION
Signed-off-by: Matias Zuniga <matias.nicolas.zc@gmail.com>

As mentioned in reactioncommerce/reaction#6519, formatMoney.js multiplies the amount by 100 when the scale is 0, apparently assuming that it means the currency should show the amount in "cents".

Because that's not always true, add a new field called "showCents". Set it as true for most of the currencies with scale=0 (to maintain the current behaviour) except for ISK and CLP, where i know this shouldn't happen.