### PR TITLE
Update decodeOpaqueId.js

### DIFF
--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -1,14 +1,22 @@
+import config from "./config.js";
+
 /**
  * @name decodeOpaqueId
  * @method
  * @memberof GraphQL/Transforms
- * @summary Transforms an opaque ID to an internal ID
+ * @summary Transforms an opaque ID to an internal ID. Returns the `id`
+ *   unchanged and the `namespace` as null if the `REACTION_SHOULD_ENCODE_IDS` 
+ *   environment variable is `false`
  * @param {String} opaqueId The ID to transform
  * @returns {String} An internal ID
  */
 export default function decodeOpaqueId(opaqueId) {
   if (opaqueId === undefined || opaqueId === null) return null;
 
+  if (config.REACTION_SHOULD_ENCODE_IDS === false) {
+    return { namespace: null, id: opaqueId };
+  }
+  
   const [namespace, id] = Buffer
     .from(opaqueId, "base64")
     .toString("utf8")

--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -5,7 +5,7 @@ import config from "./config.js";
  * @method
  * @memberof GraphQL/Transforms
  * @summary Transforms an opaque ID to an internal ID. Returns the `id`
- *   unchanged and the `namespace` as null if the `REACTION_SHOULD_ENCODE_IDS` 
+ *   unchanged and the `namespace` as null if the `REACTION_SHOULD_ENCODE_IDS`
  *   environment variable is `false`
  * @param {String} opaqueId The ID to transform
  * @returns {String} An internal ID
@@ -17,8 +17,7 @@ export default function decodeOpaqueId(opaqueId) {
     return { namespace: null, id: opaqueId };
   }
 
-  const [namespace, id] = Buffer
-    .from(opaqueId, "base64")
+  const [namespace, id] = Buffer.from(opaqueId, "base64")
     .toString("utf8")
     .split(":", 2);
 

--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -16,7 +16,7 @@ export default function decodeOpaqueId(opaqueId) {
   if (config.REACTION_SHOULD_ENCODE_IDS === false) {
     return { namespace: null, id: opaqueId };
   }
-  
+
   const [namespace, id] = Buffer
     .from(opaqueId, "base64")
     .toString("utf8")

--- a/lib/decodeOpaqueId.test.js
+++ b/lib/decodeOpaqueId.test.js
@@ -1,4 +1,13 @@
+import { jest } from "@jest/globals";
+import config from "./config.js";
 import decodeOpaqueId from "./decodeOpaqueId.js";
+
+jest.mock("./config.js", () => ({
+  __esModule: true, // this property makes it work
+  default: {
+    REACTION_SHOULD_ENCODE_IDS: true,
+  },
+}));
 
 test("decodes base64", () => {
   const encodedId = "cmVhY3Rpb24vc2hvcDpieTV3cGRnM25NcThnWDU0Yw==";
@@ -14,4 +23,14 @@ test("passes through non-base64", () => {
     id,
     namespace: null
   });
+});
+
+test("skips decoding if REACTION_SHOULD_ENCODE_IDS env is false", async () => {
+  const id = "by5wpdg3nMq8gX54c";
+  config.REACTION_SHOULD_ENCODE_IDS = false;
+  expect(decodeOpaqueId(id)).toEqual({
+    id,
+    namespace: null
+  });
+  config.REACTION_SHOULD_ENCODE_IDS = true;
 });

--- a/lib/decodeOpaqueId.test.js
+++ b/lib/decodeOpaqueId.test.js
@@ -5,8 +5,8 @@ import decodeOpaqueId from "./decodeOpaqueId.js";
 jest.mock("./config.js", () => ({
   __esModule: true, // this property makes it work
   default: {
-    REACTION_SHOULD_ENCODE_IDS: true,
-  },
+    REACTION_SHOULD_ENCODE_IDS: true
+  }
 }));
 
 test("decodes base64", () => {


### PR DESCRIPTION
This is required in order to be consistent with: https://github.com/reactioncommerce/api-utils/blob/f7690705c49c4a0d94799ed3deaf6be9ff909f76/lib/encodeOpaqueId.js#L20

Since the entire encoding/decoding of IDs was built for a reason that is no longer valid, we've found it very practical to simply set the environment variable REACTION_SHOULD_ENCODE_IDS to false. This makes development considerably easier, especially for quick API tests with graphQL playground. 
But in order for that to work, `decodeOpaqueId()` should also check for the env variable. If we don't do that, `decodeOpaqueId()` can return wrong `namespace` and `id` values.

(Note that `decodeOpaqueId()` did NOT always fail prior to our change. For example, decoding  `reaction/mediaRecord:xifjgK9ckbptZ2ew2` will yield a null namespace and return the ID as is (because there's no `:` character to split on I believe), whereas decoding ID `reaction/mediaRecord:dTp6az9ghgoLSGGTo` will yield a namespace equal to `u` and a wrong ID)