### PR TITLE
(fix) Use conditional exports to fix require() from .cjs module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,18 @@
     "url": "https://github.com/reactioncommerce/api-utils/issues"
   },
   "exports": {
-    "./": "./lib/",
-    "./graphql/": "./lib/graphql/",
-    "./tests/": "./lib/tests/"
+    "./": {
+      "require": "./",
+      "default": "./lib/"
+    },
+    "./graphql/": {
+      "require": "./",
+      "default": "./lib/graphql/"
+    },
+    "./tests/": {
+      "require": "./",
+      "default": "./lib/tests/"
+    }
   },
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
This is a fix for loading config files when running tests, such as [jest.config.cjs](https://github.com/reactioncommerce/api-plugin-accounts/blob/784f6d229fa001279e767ef40306151cd518664f/babel.config.cjs#L1).

When using Node.js 14+, it will try to resolve from `exports` defined in `packages.json`. Unfortunately, `require()` behaves differently other than `import`.

Say I have a directory structure like

```
/tmp
├── main.cjs
├── node_modules
│   └── api-utils
```

The content of `main.cjs` is:
```js
let main = require("api-utils/configs/jest.config.cjs");
console.log(Object.keys(main));
```
Without the fix, when doing `node main.cjs` will output like
```
internal/modules/cjs/loader.js:443
      throw e;
      ^

Error: Cannot find module '/tmp/node_modules/api-utils/lib/lib/configs/jest.config.cjs'
```

The expected result is:
```
[ 'moduleNameMapper', 'testEnvironment', 'transformIgnorePatterns' ]
```
