### PR TITLE
Don't include `$skip` if value is 0

### DIFF
--- a/lib/graphql/applyOffsetPaginationToMongoAggregate.js
+++ b/lib/graphql/applyOffsetPaginationToMongoAggregate.js
@@ -23,18 +23,20 @@ export default async function applyOffsetPaginationToMongoAggregate(collection, 
   const limit = first || DEFAULT_LIMIT;
   const newPipeline = [...pipeline];
 
+  const hasPreviousPage = offset > 0;
+
   // Apply limit + skip to the provided pipeline
-  newPipeline.push({
-    "$skip": offset
-  });
+  if (hasPreviousPage) {
+    newPipeline.push({
+      "$skip": offset
+    });
+  }
 
   newPipeline.push({
     "$limit": limit
   });
 
   let hasNextPage = null;
-
-  const hasPreviousPage = offset > 0;
 
   if (includeHasNextPage) {
     const nextCursor = collection.aggregate(pipeline);

--- a/lib/graphql/applyPaginationToMongoAggregate.js
+++ b/lib/graphql/applyPaginationToMongoAggregate.js
@@ -76,7 +76,7 @@ export default async function applyPaginationToMongoAggregate(collection, pipeli
     "$limit": limit
   });
 
-  if (skip) {
+  if (skip > 0) {
     pipeline.push({
       "$skip": skip
     });


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

In some cases, `applyPaginationToMongoAggregate` and `applyOffsetPaginationToMongoAggregate` may include `$skip` in the pipeline even though the value is `0`. `$skip: 0` not being allowed in aggregations, this causes no results to be returned.

This PR solves this by omitting the `$skip` stage if the value is 0.