### PR TITLE
Fix `totalCount` on `getPaginatedResponseFromAggregate`

### DIFF
--- a/lib/graphql/getPaginatedResponseFromAggregate.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.js
@@ -39,10 +39,42 @@ async function getPaginatedResponseFromAggregate(collection, pipeline, args, {
   let totalCount = null;
   if (includeTotalCount) {
     pipeline.push({
-      "$addFields": {
+      /**
+       * This stage gathers all of the objects that the pipeline has returned into a single array in one document.
+       * Because we have all the documents in a single array, we can now count them using $sum. Unfortunately the only
+       * way to count the number of returned objects with aggregates, as `.count()` is not available on aggregates.
+       */
+      $group: {
+        _id: null,
+        objects: {
+          $addToSet: "$$ROOT"
+        },
         totalCount: {
-          "$sum": 1
+          $sum: 1
         }
+      }
+    }, {
+      /**
+       * Now that we've calculated the total count of objects, we can $unwind our array in our single object to get
+       * individual objects again.
+       */
+      $unwind: {
+        path: "$objects"
+      }
+    }, {
+      /**
+       * Set `totalCount` inside of our objects, since we'll replace the root in the next stage.
+       */
+      $set: {
+        "$objects.totalCount": "$totalCount"
+      }
+    }, {
+      /**
+       * Replace the root. We now have all the objects that were returned by the pipeline originally, but with a new
+       * `totalCount` field in each of them that contains the total count of objects returned.
+       */
+      $replaceRoot: {
+        newRoot: "$objects"
       }
     });
   }

--- a/lib/graphql/getPaginatedResponseFromAggregate.test.js
+++ b/lib/graphql/getPaginatedResponseFromAggregate.test.js
@@ -56,10 +56,29 @@ test("includes sort param in pipeline and returns correct result", async () => {
         "$someOperator": "someParameter"
       },
       {
-        "$addFields": {
+        "$group": {
+          _id: null,
+          objects: {
+            "$addToSet": "$$ROOT"
+          },
           totalCount: {
             "$sum": 1
           }
+        }
+      },
+      {
+        $unwind: {
+          path: "$objects"
+        }
+      },
+      {
+        $set: {
+          "$objects.totalCount": "$totalCount"
+        }
+      },
+      {
+        $replaceRoot: {
+          newRoot: "$objects"
         }
       },
       {
@@ -84,10 +103,29 @@ test("returns totalCount == 0 when there are no documents", async () => {
         "$someOperator": "someParameter"
       },
       {
-        "$addFields": {
+        "$group": {
+          _id: null,
+          objects: {
+            "$addToSet": "$$ROOT"
+          },
           totalCount: {
             "$sum": 1
           }
+        }
+      },
+      {
+        $unwind: {
+          path: "$objects"
+        }
+      },
+      {
+        $set: {
+          "$objects.totalCount": "$totalCount"
+        }
+      },
+      {
+        $replaceRoot: {
+          newRoot: "$objects"
         }
       },
       {


### PR DESCRIPTION
Fixes #80

This PR implements `totalCount` in a way that actually works with all aggregates.

Unfortunately, the `.count()` cursor method (which we use to get the `totalCount` on normal, non-aggregate queries) is not available on aggregates. This is why we've had to resort to using `$addFields` with a `$sum` operator in the past to get the total number of objects returned by a given aggregate.

This doesn't seem to work anymore, as `getPaginatedResponseFromAggregate` always seems to return `totalCount: 1`.

My new implementation seems to be the only reliable way to count the total number of returned objects with an aggregate. I've detailed it with comments directly in the code, but I'll give a breakdown here as well:

## Stage 1: `$group` into a single array

We group all of the objects returned by the pipeline at this point into a single array, in a single object. This allows us to add a `totalCount` field that is the `$sum` of that array, giving us the total number of objects.

## Stage 2: `$unwind` to get back our individual objects

Stage 1 leaves us with a single object and all of our results in a single array. We obviously want individual objects, so we use `$unwind` on that array.

## Stage 3: `$set` our `totalCount` field inside the unwinded object

At the end of Stage 2, we have our `totalCount` field, but it's outside of our object. Because we're going to `$replaceRoot` with that object in the next stage, we want to move out `totalCount` field into this object so we don't lose it.

## Stage 4: `$replaceRoot` to get a clean, non-nested result

We use `$replaceRoot` to have a result that only returns the objects that the pipeline would have otherwise returned, with the only difference that all objects now have a `totalCount` field with the total count of returned objects.



If this pipeline for `totalCount` isn't clear with my comments, I would recommend checking it out stage by stage with MongoDB Compass. Things will make more sense by being able to see what happens at every stage.