### PR TITLE
Fix 77 product slug decoding

### DIFF
--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -14,7 +14,7 @@ export default function decodeOpaqueId(opaqueId) {
     .toString("utf8")
     .split(":", 2);
 
-  if (namespace && namespace.includes("reaction/") && id) {
+  if (namespace && namespace.startsWith("reaction/") && id) {
     return { namespace, id };
   }
 

--- a/lib/decodeOpaqueId.js
+++ b/lib/decodeOpaqueId.js
@@ -14,7 +14,7 @@ export default function decodeOpaqueId(opaqueId) {
     .toString("utf8")
     .split(":", 2);
 
-  if (namespace && id) {
+  if (namespace && namespace.includes("reaction/") && id) {
     return { namespace, id };
   }
 


### PR DESCRIPTION
Fixes #77 and #92 

# Issue
Certain slug values like `8706401` gets decoded to namespace and id with junk values. This in turn fails `catalogProductItem` query using slugId. 

# Solution
A check is added to ensure that the decoded namespace is a reaction namespace and not some random values. 

# Testing
- Create a product with title `8706401` (the same value is assigned to slug".
- In GQL playground run
```
query{
  catalogItemProduct(slugOrId:"`8706401`"){
    _id
    shop{
      name
      slug
    }
    product{
      slug
      _id
    }
    
  }
}
```
- Without the fix you should see a namespace error. Expected behavior should return the catalog item properly.
