### PR TITLE
chore: circleci build enabled for all

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,7 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - build:
-          context: reaction-publish-semantic-release
+      - build
       - lint:
           requires:
             - build


### PR DESCRIPTION
This PR resolves the issue where the build was not working for all community members.