### PR TITLE
chore: update currency and country definations for Zambia (ZM)

### DIFF
--- a/lib/CountryDefinitions.js
+++ b/lib/CountryDefinitions.js
@@ -2533,7 +2533,7 @@ export default {
     phone: "260",
     continent: "AF",
     capital: "Lusaka",
-    currency: "ZMK",
+    currency: "ZMW",
     languages: "en"
   },
   ZW: {

--- a/lib/CurrencyDefinitions.js
+++ b/lib/CurrencyDefinitions.js
@@ -437,5 +437,5 @@ export default {
   ZMW: {
     format: "%s%v",
     symbol: "ZMW"
-  },
+  }
 };

--- a/lib/CurrencyDefinitions.js
+++ b/lib/CurrencyDefinitions.js
@@ -433,5 +433,9 @@ export default {
     format: "%v %s",
     symbol: "CFA",
     scale: 0
-  }
+  },
+  ZMW: {
+    format: "%s%v",
+    symbol: "ZMW"
+  },
 };


### PR DESCRIPTION
Resolves #103 
Impact: **minor**
Type: **chore**

## Issue

- At the moment Zambian (ZM) currency ZMW is not present in the platform but country is present.
- Zambian currency updated from ZMK to ZMW but the currency field of country definations still has ZMK on Zambia

## Solution
- I added missing currency definations for zambia in the currency defination file. 
- I updated the currency field of the for Zambia to ZMW in the country definations file 

## Breaking changes
none